### PR TITLE
Replace log with logrus

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -6,7 +6,7 @@ package clients
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	cloud_network "github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/client"

--- a/internal/clients/hvn_route.go
+++ b/internal/clients/hvn_route.go
@@ -6,7 +6,7 @@ package clients
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/client/network_service"

--- a/internal/clients/logging.go
+++ b/internal/clients/logging.go
@@ -5,7 +5,7 @@ package clients
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 )

--- a/internal/clients/operation.go
+++ b/internal/clients/operation.go
@@ -6,7 +6,7 @@ package clients
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-operation/stable/2020-05-05/client/operation_service"

--- a/internal/provider/data_source_aws_network_peering.go
+++ b/internal/provider/data_source_aws_network_peering.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_boundary_cluster.go
+++ b/internal/provider/data_source_boundary_cluster.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/stable/2021-02-04/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_hvn.go
+++ b/internal/provider/data_source_hvn.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_hvn_peering_connection.go
+++ b/internal/provider/data_source_hvn_peering_connection.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_hvn_route.go
+++ b/internal/provider/data_source_hvn_route.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/client/network_service"

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_azure_peering_connection.go
+++ b/internal/provider/resource_azure_peering_connection.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/client/network_service"

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	boundarymodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-boundary-service/stable/2021-12-21/models"

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_consul_cluster_root_token.go
+++ b/internal/provider/resource_consul_cluster_root_token.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path/filepath"
 	"strings"
 	"time"

--- a/internal/provider/resource_consul_snapshot.go
+++ b/internal/provider/resource_consul_snapshot.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_hvn_peering_connection.go
+++ b/internal/provider/resource_hvn_peering_connection.go
@@ -5,7 +5,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/stable/2020-09-07/client/network_service"

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_vault_cluster_admin_token.go
+++ b/internal/provider/resource_vault_cluster_admin_token.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-hcp', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
templates
.changelog
.release
design
scripts
.github
docs
internal
tools
.git
contributing
version
.vscode
provider
data-sources
resources
guides
hcp_boundary_cluster
hcp_hvn_peering_connection
hcp_vault_cluster
hcp_consul_versions
hcp_consul_cluster
hcp_hvn_route
hcp_hvn
hcp_aws_transit_gateway_attachment
hcp_azure_peering_connection
hcp_packer_image_iteration
hcp_aws_network_peering
hcp_packer_iteration
hcp_packer_image
hcp_consul_agent_kubernetes_secret
hcp_consul_agent_helm_config
hcp_boundary_cluster
hcp_hvn_peering_connection
hcp_vault_cluster
hcp_consul_cluster
hcp_packer_channel
hcp_hvn_route
hcp_consul_cluster_root_token
hcp_hvn
hcp_vault_cluster_admin_token
hcp_aws_transit_gateway_attachment
hcp_azure_peering_connection
hcp_aws_network_peering
hcp_consul_snapshot
scaling
vault_perf_replication
snapshots
hvn_route_migration_guide
consul_cluster_root_token
peering
auth
consul_cluster_federation
vault_cluster_admin_token
data-sources
resources
guides
workflows
ISSUE_TEMPLATE
data-sources
resources
guides
provider
clients
consul
input
objects
info
branches
logs
refs
hooks
97
1b
31
08
8d
65
20
9f
24
4e
eb
6e
18
b6
e2
78
b0
49
fe
bd
57
89
c5
1e
d0
1c
44
95
72
dc
12
b7
ee
11
22
53
7a
47
5c
7c
07
fa
59
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
69
42
a9
6c
db
dd
76
43
3e
34
60
c9
4c
05
ca
26
06
a4
d2
85
19
fd
82
9b
f3
fb
b8
b4
cb
0b
c1
a6
0f
74
93
61
5b
51
cf
d1
c7
de
f6
e9
pack
f7
ef
9a
e8
da
d7
ce
79
3a
b5
ae
be
28
info
f8
80
ed
a7
9d
15
a5
56
c6
2b
09
2e
d4
4b
50
98
73
6d
27
3b
70
7e
bc
46
88
0c
c0
af
a8
5e
35
b1
40
67
aa
ab
8c
3d
41
b9
6b
37
4f
d3
0d
33
2f
8f
d9
39
36
55
63
17
77
c4
92
f9
c3
04
38
64
7b
48
32
91
6a
14
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)